### PR TITLE
Fix for including ../ in require paths

### DIFF
--- a/lib/snockets.js
+++ b/lib/snockets.js
@@ -1,7 +1,6 @@
 (function() {
-  var CoffeeScript, DIRECTIVE, DepGraph, EXPLICIT_PATH, HEADER, HoldingQueue, Snockets, compilers, fs, jsExts, minify, parseDirectives, path, stripExt, timeEq, uglify, _,
-    __slice = Array.prototype.slice,
-    __indexOf = Array.prototype.indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
+  var CoffeeScript, DIRECTIVE, DepGraph, EXPLICIT_PATH, HEADER, HoldingQueue, Snockets, compilers, fs, jsExts, minify, parseDirectives, path, stripExt, timeEq, uglify, _;
+  var __slice = Array.prototype.slice, __hasProp = Object.prototype.hasOwnProperty, __indexOf = Array.prototype.indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (__hasProp.call(this, i) && this[i] === item) return i; } return -1; };
 
   DepGraph = require('dep-graph');
 
@@ -17,26 +16,25 @@
 
   module.exports = Snockets = (function() {
 
-    Snockets.name = 'Snockets';
-
     function Snockets(options) {
-      var _base, _base2;
+      var _base, _base2, _ref, _ref2;
       this.options = options != null ? options : {};
-      if ((_base = this.options).src == null) _base.src = '.';
-      if ((_base2 = this.options).async == null) _base2.async = true;
+      if ((_ref = (_base = this.options).src) == null) _base.src = '.';
+      if ((_ref2 = (_base2 = this.options).async) == null) _base2.async = true;
       this.cache = {};
       this.concatCache = {};
       this.depGraph = new DepGraph;
     }
 
     Snockets.prototype.scan = function(filePath, flags, callback) {
+      var _ref;
       var _this = this;
       if (typeof flags === 'function') {
         callback = flags;
         flags = {};
       }
       if (flags == null) flags = {};
-      if (flags.async == null) flags.async = this.options.async;
+      if ((_ref = flags.async) == null) flags.async = this.options.async;
       return this.updateDirectives(filePath, flags, function(err, graphChanged) {
         if (err) {
           if (callback) {
@@ -53,13 +51,14 @@
     };
 
     Snockets.prototype.getCompiledChain = function(filePath, flags, callback) {
+      var _ref;
       var _this = this;
       if (typeof flags === 'function') {
         callback = flags;
         flags = {};
       }
       if (flags == null) flags = {};
-      if (flags.async == null) flags.async = this.options.async;
+      if ((_ref = flags.async) == null) flags.async = this.options.async;
       return this.updateDirectives(filePath, flags, function(err, graphChanged) {
         var chain, compiledChain, link, o;
         if (err) {
@@ -79,11 +78,11 @@
           }
         }
         compiledChain = (function() {
-          var _i, _len, _ref, _results;
-          _ref = chain.concat(filePath);
+          var _i, _len, _ref2, _results;
+          _ref2 = chain.concat(filePath);
           _results = [];
-          for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-            link = _ref[_i];
+          for (_i = 0, _len = _ref2.length; _i < _len; _i++) {
+            link = _ref2[_i];
             o = {};
             if (this.compileFile(link)) {
               o.filename = stripExt(link) + '.js';
@@ -103,17 +102,17 @@
     };
 
     Snockets.prototype.getConcatenation = function(filePath, flags, callback) {
-      var concatenationChanged,
-        _this = this;
+      var concatenationChanged, _ref;
+      var _this = this;
       if (typeof flags === 'function') {
         callback = flags;
         flags = {};
       }
       if (flags == null) flags = {};
-      if (flags.async == null) flags.async = this.options.async;
+      if ((_ref = flags.async) == null) flags.async = this.options.async;
       concatenationChanged = true;
       return this.updateDirectives(filePath, flags, function(err, graphChanged) {
-        var chain, concatenation, link, result, _ref, _ref2;
+        var chain, concatenation, link, result, _ref2, _ref3;
         if (err) {
           if (callback) {
             return callback(err);
@@ -122,17 +121,17 @@
           }
         }
         try {
-          if ((_ref = _this.concatCache[filePath]) != null ? _ref.data : void 0) {
+          if ((_ref2 = _this.concatCache[filePath]) != null ? _ref2.data : void 0) {
             concatenation = _this.concatCache[filePath].data.toString('utf8');
             if (!flags.minify) concatenationChanged = false;
           } else {
             chain = _this.depGraph.getChain(filePath);
             concatenation = ((function() {
-              var _i, _len, _ref2, _results;
-              _ref2 = chain.concat(filePath);
+              var _i, _len, _ref3, _results;
+              _ref3 = chain.concat(filePath);
               _results = [];
-              for (_i = 0, _len = _ref2.length; _i < _len; _i++) {
-                link = _ref2[_i];
+              for (_i = 0, _len = _ref3.length; _i < _len; _i++) {
+                link = _ref3[_i];
                 this.compileFile(link);
                 _results.push(this.cache[link].js.toString('utf8'));
               }
@@ -150,7 +149,7 @@
           }
         }
         if (flags.minify) {
-          if ((_ref2 = _this.concatCache[filePath]) != null ? _ref2.minifiedData : void 0) {
+          if ((_ref3 = _this.concatCache[filePath]) != null ? _ref3.minifiedData : void 0) {
             result = _this.concatCache[filePath].minifiedData.toString('utf8');
             concatenationChanged = false;
           } else {
@@ -168,8 +167,8 @@
     };
 
     Snockets.prototype.updateDirectives = function() {
-      var callback, depList, excludes, filePath, flags, graphChanged, q, require, requireTree, _i,
-        _this = this;
+      var callback, depList, excludes, filePath, flags, graphChanged, q, require, requireTree, _i;
+      var _this = this;
       filePath = arguments[0], flags = arguments[1], excludes = 4 <= arguments.length ? __slice.call(arguments, 2, _i = arguments.length - 1) : (_i = 2, []), callback = arguments[_i++];
       if (__indexOf.call(excludes, filePath) >= 0) return callback();
       excludes.push(filePath);
@@ -269,8 +268,8 @@
     };
 
     Snockets.prototype.findMatchingFile = function(filename, flags, callback) {
-      var tryFiles,
-        _this = this;
+      var tryFiles;
+      var _this = this;
       tryFiles = function(filePaths) {
         var filePath, _i, _len;
         for (_i = 0, _len = filePaths.length; _i < _len; _i++) {
@@ -398,15 +397,13 @@
     }
   };
 
-  EXPLICIT_PATH = /^\/|^\.|:/;
+  EXPLICIT_PATH = /^\/|:/;
 
   HEADER = /(?:(\#\#\#.*\#\#\#\n*)|(\/\/.*\n*)|(\#.*\n*))+/;
 
   DIRECTIVE = /^[\W]*=\s*(\w+.*?)(\*\\\/)?$/gm;
 
   HoldingQueue = (function() {
-
-    HoldingQueue.name = 'HoldingQueue';
 
     function HoldingQueue(_arg) {
       this.task = _arg.task, this.onComplete = _arg.onComplete;
@@ -422,8 +419,8 @@
     };
 
     HoldingQueue.prototype.perform = function() {
-      var args, key,
-        _this = this;
+      var args, key;
+      var _this = this;
       key = arguments[0], args = 2 <= arguments.length ? __slice.call(arguments, 1) : [];
       return this.task.apply(this, __slice.call(args).concat([function() {
         return _this.unwaitFor(key);
@@ -431,8 +428,8 @@
     };
 
     HoldingQueue.prototype.finalize = function() {
-      var h,
-        _this = this;
+      var h;
+      var _this = this;
       if (this.holdKeys.length === 0) {
         return this.onComplete();
       } else {

--- a/src/snockets.coffee
+++ b/src/snockets.coffee
@@ -251,7 +251,7 @@ module.exports.compilers = compilers =
 
 # ## Regexes
 
-EXPLICIT_PATH = /^\/|^\.|:/
+EXPLICIT_PATH = /^\/|:/
 
 HEADER = ///
 (?:

--- a/test/assets/first/syblingFolder.js
+++ b/test/assets/first/syblingFolder.js
@@ -1,0 +1,1 @@
+//= require ../sybling/sybling.js

--- a/test/assets/sybling/sybling.js
+++ b/test/assets/sybling/sybling.js
@@ -1,0 +1,1 @@
+var thereWillBeJS = 3;

--- a/test/integration.coffee
+++ b/test/integration.coffee
@@ -54,6 +54,13 @@ testSuite =
       test.deepEqual chain, ['branch/edge.coffee', 'branch/periphery.js', 'branch/subbranch/leaf.js']
       test.done()
 
+  'require works for includes that are relative to orig file using ../': (test) ->
+    snockets.scan 'first/syblingFolder.js', (err) ->
+      throw err if err
+      chain = snockets.depGraph.getChain('first/syblingFolder.js')
+      test.deepEqual chain, ['sybling/sybling.js']
+      test.done()
+
   'require_tree works for nested directories': (test) ->
     snockets.scan 'fellowship.js', (err) ->
       throw err if err
@@ -76,6 +83,24 @@ testSuite =
         {filename: 'y.js', js: '//= require x'}
         {filename: 'z.js', js: '(function() {\n\n}).call(this);\n'}
       ]
+      test.done()
+
+  'getCompiledChain returns correct .js filenames and code with ../ in require path': (test) ->
+    snockets.getCompiledChain 'first/syblingFolder.js', (err, chain) ->
+      throw err if err
+      test.deepEqual chain, [
+        {filename: 'sybling/sybling.js', js: 'var thereWillBeJS = 3;'}
+        {filename: 'first/syblingFolder.js', js: '//= require ../sybling/sybling.js'}
+      ]
+      test.done()
+
+  'getConcatenation returns correct raw JS code with ../ in require path': (test) ->
+    snockets.getConcatenation 'first/syblingFolder.js', (err, js1, changed) ->
+      throw err if err
+      test.equal js1, """
+        var thereWillBeJS = 3;
+        //= require ../sybling/sybling.js
+      """
       test.done()
 
   'getConcatenation returns correct raw JS code': (test) ->


### PR DESCRIPTION
It looks like removing the check for . in the EXPLICIT_PATH regex makes it so that having a ../ in your path will work correctly.  All of the tests pass with this change and I couldn't think of any reason that the . should be checked for in the EXPLICIT_PATH check.
