### PR TITLE
If any dependent file is modified, then the current file should be "modified"

### DIFF
--- a/lib/snockets.js
+++ b/lib/snockets.js
@@ -209,10 +209,11 @@
           if (__indexOf.call(depList, depPath) < 0) {
             depList.push(depPath);
           }
-          return _this.updateDirectives.apply(_this, [depPath, flags].concat(__slice.call(excludes), [function(err) {
+          return _this.updateDirectives.apply(_this, [depPath, flags].concat(__slice.call(excludes), [function(err, depChanged) {
             if (err) {
               return callback(err);
             }
+            graphChanged || (graphChanged = depChanged);
             return next();
           }]));
         },

--- a/src/snockets.coffee
+++ b/src/snockets.coffee
@@ -112,7 +112,7 @@ module.exports = class Snockets
           depList.push depPath
         @updateDirectives depPath, flags, excludes..., (err, depChanged) ->
           return callback err if err
-          graphChanged = depChanged
+          graphChanged or= depChanged
           next()
       onComplete: =>
         unless _.isEqual depList , @depGraph.map[filePath]

--- a/src/snockets.coffee
+++ b/src/snockets.coffee
@@ -110,8 +110,9 @@ module.exports = class Snockets
           return callback err
         unless depPath in depList
           depList.push depPath
-        @updateDirectives depPath, flags, excludes..., (err) ->
+        @updateDirectives depPath, flags, excludes..., (err, depChanged) ->
           return callback err if err
+          graphChanged = depChanged
           next()
       onComplete: =>
         unless _.isEqual depList , @depGraph.map[filePath]


### PR DESCRIPTION
main.coffee

```
#= require 'dep'
```

dep.coffee

```
foo =-> 'hello world'
```

if dep.coffee is "graphChanged", then main.coffee should also be "graphChanged".  I was using connect-assets and it wouldn't update my javascript when changing a dependency (https://github.com/TrevorBurnham/connect-assets/blob/master/src/assets.coffee#L213).  Am I missing something or was this just an oversight?
