### PR TITLE
Snockets output is dependent on file list ordering when using require_tree

### DIFF
--- a/lib/snockets.js
+++ b/lib/snockets.js
@@ -247,14 +247,15 @@
       requireTree = function(dirName) {
         q.waitFor(dirName);
         return _this.readdir(_this.absPath(dirName), flags, function(err, items) {
-          var item, itemPath, _j, _len, _results;
+          var item, itemPath, _j, _len, _ref, _results;
           if (err) {
             return callback(err);
           }
           q.unwaitFor(dirName);
+          _ref = items.sort();
           _results = [];
-          for (_j = 0, _len = items.length; _j < _len; _j++) {
-            item = items[_j];
+          for (_j = 0, _len = _ref.length; _j < _len; _j++) {
+            item = _ref[_j];
             itemPath = _this.joinPath(dirName, item);
             if (_this.absPath(itemPath) === _this.absPath(filePath)) {
               continue;

--- a/src/snockets.coffee
+++ b/src/snockets.coffee
@@ -138,7 +138,7 @@ module.exports = class Snockets
       @readdir @absPath(dirName), flags, (err, items) =>
         return callback err if err
         q.unwaitFor dirName
-        for item in items
+        for item in items.sort()
           itemPath = @joinPath dirName, item
           continue if @absPath(itemPath) is @absPath(filePath)
           q.waitFor itemPath


### PR DESCRIPTION
`require_tree` uses `fs.readdir` and `fs.readdirSync`, but `snockets` doesn't sort these files before it does the concatenation. This is causing an issue for me because I'm using my app with Heroku. I have 2 dynos running and both are generating different static assets with different static asset md5 hashes. Depending on which dyno you hit, you might get a 404 when you request a specific asset. I believe that each dyno is doing it's `require_tree` in a different order, therefore the content and hash ends up being different.
